### PR TITLE
Remove './lib' from @INC for cron_event_predict.plx

### DIFF
--- a/cron_event_predict.plx
+++ b/cron_event_predict.plx
@@ -1,6 +1,6 @@
 #!/usr/local/bin/perl -w
 use strict;
-use lib './lib';
+
 use Schedule::Cron::Events;
 use Getopt::Std;
 use Time::Local;


### PR DESCRIPTION
cron_event_predict.plx only need to use './lib' for testing
and should not use an 'unpredictable' path in production
or this could lead to unsafe code being loaded and run with an
unpredictable user.